### PR TITLE
Show periodic-reincarnation.png for Naginator plugin build cause.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/buildtriggerbadge/BuildTriggerBadgeAction.java
+++ b/src/main/java/org/jenkinsci/plugins/buildtriggerbadge/BuildTriggerBadgeAction.java
@@ -77,6 +77,7 @@ public class BuildTriggerBadgeAction implements BuildBadgeAction {
 		iconPaths.put("org.jvnet.hudson.plugins.m2release.ReleaseCause", "user-cause.png");
 		iconPaths.put("com.cloudbees.jenkins.GitHubPushCause", "github-push-cause.png");
 		iconPaths.put("org.jenkinsci.plugins.periodicreincarnation.PeriodicReincarnationBuildCause", "periodic-reincarnation.png");
+		iconPaths.put("com.chikli.hudson.plugin.naginator.NaginatorCause", "periodic-reincarnation.png");
 	}
 
 	public static BuildTriggerBadgePlugin getPlugin() {


### PR DESCRIPTION
I'm reusing the icon that was added for the periodic reincarnation plugin because the image works for both. Let me know if you prefer renaming the image to make it generic.
