### PR TITLE
Added extension point for overwritting the icon rendering

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/buildtriggerbadge/BuildTriggerBadgeValidator.java
+++ b/src/main/java/org/jenkinsci/plugins/buildtriggerbadge/BuildTriggerBadgeValidator.java
@@ -1,0 +1,49 @@
+/*
+ *  The MIT License
+
+
+ *
+ *  Copyright 2010 Sony Ericsson Mobile Communications. All rights reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.buildtriggerbadge;
+
+import hudson.ExtensionPoint;
+import hudson.model.Cause;
+
+import java.io.Serializable;
+
+/**
+ * Extension point for allowing disabling of the default icon, in case the class type of the Cause is more specialised
+ * 
+ * @author Ionut-Catalin Poitasu &lt;catalin.poitasu@gmail.com&gt;
+ */
+
+public abstract class BuildTriggerBadgeValidator implements Serializable, ExtensionPoint {
+	/**
+     * Method for acknowledging that another plug-in wants to handle the icon rendering functionality itself.
+     *
+     * @param cause Cause to use when verifying applicability
+     * @return true if the plug-in provides its own icon to attach to a build, as a representation of a cause. This will disable the build-trigger-badge plugin for this cause.
+     */
+	
+    public abstract boolean isApplicable(Cause cause);
+}

--- a/src/main/java/org/jenkinsci/plugins/buildtriggerbadge/RunListenerImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/buildtriggerbadge/RunListenerImpl.java
@@ -1,6 +1,8 @@
 package org.jenkinsci.plugins.buildtriggerbadge;
 
 import hudson.Extension;
+import hudson.ExtensionList;
+
 import hudson.model.AbstractBuild;
 import hudson.model.Cause;
 import hudson.model.TaskListener;
@@ -19,24 +21,44 @@ import jenkins.model.Jenkins;
  */
 @Extension
 public class RunListenerImpl extends RunListener<AbstractBuild> {
-	
+
 	public RunListenerImpl() {
 		super(AbstractBuild.class);
 	}
-	
+
 	@Override
 	public void onStarted(AbstractBuild build, TaskListener listener) {
 		BuildTriggerBadgePlugin plugin = Jenkins.getInstance().getPlugin(BuildTriggerBadgePlugin.class);
-		if(plugin.isActivated()) {
-			Set<String> causeClasses =  new HashSet<String>();
-			List<Cause> causes = CauseFilter.filter((List<Cause>)build.getCauses());
+		if (plugin.isActivated()) {
+			Set<String> causeClasses = new HashSet<String>();
+			List<Cause> causes = CauseFilter.filter((List<Cause>) build.getCauses());
 			if (causes != null) {
+				// get the extension list for BuildTriggerBadgeValidator
+				ExtensionList<BuildTriggerBadgeValidator> btbValidatorExtensionList = Jenkins.getInstance().getExtensionList(BuildTriggerBadgeValidator.class);
+				
 				for (Cause cause : causes) {
-					build.addAction(new BuildTriggerBadgeAction(cause));
+					
+					// assume the cause icon was not handled differently
+					boolean isApplicable = false;
+					
+					// go through all the implementations of the extension point BuildTriggerBadgeValidator, if they exist
+					for (BuildTriggerBadgeValidator buildTriggerBadgeValidator : btbValidatorExtensionList) {
+				
+						// check if the cause in question has an overwriting icon defied outside of this plugin
+						// this functionality in an opt-in feature which should become active only then the below check is verified, for at least one extension
+						if (buildTriggerBadgeValidator.isApplicable(cause)) {
+							isApplicable = true;
+						}
+					}
+
+					// default case of handling the assignment of icons to the specific cause types, when no extension point overwrote the functionality
+					if (isApplicable == false) {
+						build.addAction(new BuildTriggerBadgeAction(cause));
+					}
 				}
 			}
 		}
 		super.onStarted(build, listener);
 	}
-	
+
 }


### PR DESCRIPTION
Hi ljader,

When the cause of a build is not one of the known cause types (classes) defined by the build trigger badge, then the default question mark icon is displayed. I have implemented this extension so that one plugin can implement independently the rendering of an icon, or suppress the default icon. More specific, we have a subclass of Cause which has more info, and what is received by the build trigger badge is not known, thus being forced to go to the default icon. Hope this makes sense, for us this change is very useful, and at the same time as general as possible for this plugin, as it is an opt-in feature.

Background: we are using Jenkins in production with open-source plugins and several in-house ones.