### PR TITLE
Add an icon for Atlassian Stash pull-request cause

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/buildtriggerbadge/IconFinder.java
+++ b/src/main/java/org/jenkinsci/plugins/buildtriggerbadge/IconFinder.java
@@ -79,6 +79,7 @@ public class IconFinder {
 		defineIconForCause("com.cloudbees.plugins.flow.FlowCause", "flow-cause.png");
 		defineIconForCause("com.cloudbees.jenkins.plugins.BitBucketPushCause", "bitbucket.png");
 		defineIconForCause("hudson.plugins.git.GitStatus$CommitHookCause", "git-hook-cause.png");
+		defineIconForCause("stashpullrequestbuilder.stashpullrequestbuilder.StashCause", "github-pull-request-cause.png");
 	}
 
 	private static void defineIconForCause(Class clazz, String path) {


### PR DESCRIPTION
I reused the github PR icon which IMO is much more representative of a PR than the one used in Stash or the Stash logo itself. I don't really think there's gonna be a case where we need an icon for a Stash PR and another one for a GH PR in the same job.

If you think differently I'll update the PR. For comparison:
- Github PR: ![github-pull-request-cause](https://cloud.githubusercontent.com/assets/683385/8591496/f8337420-2628-11e5-8d45-c26504af2060.png)
- Stash PR: ![stash-pull-requests](https://cloud.githubusercontent.com/assets/683385/8591316/b46f60b0-2627-11e5-8e3b-84945005c2a1.png)
- Stash logo: ![stash_logo_productspage](https://cloud.githubusercontent.com/assets/683385/8591407/5e31d6be-2628-11e5-9b21-3c9aab4ff3d2.png)