### PR TITLE
[JENKINS-26186] Enable changing display format for Last Build Trigger Column

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/buildtriggerbadge/LastBuildTriggerColumn.java
+++ b/src/main/java/org/jenkinsci/plugins/buildtriggerbadge/LastBuildTriggerColumn.java
@@ -6,6 +6,7 @@ import java.util.Map;
 
 import net.sf.json.JSONObject;
 
+import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
 import hudson.Extension;
@@ -24,6 +25,25 @@ import hudson.views.ListViewColumn;
  * 
  */
 public class LastBuildTriggerColumn extends ListViewColumn {
+	public static final String ICON_ONLY = "iconOnly";
+	public static final String ICON_AND_DESC = "iconAndDesc";
+
+	private String causeDisplayType = "iconOnly";
+
+	@DataBoundConstructor
+	public LastBuildTriggerColumn(String causeDisplayType) {
+		super();
+		this.causeDisplayType = causeDisplayType;
+	}
+
+	public LastBuildTriggerColumn() {
+		this(ICON_ONLY);
+	}
+
+	public String getCauseDisplayType() {
+		return causeDisplayType;
+	}
+
 	private static final class BuildNodeColumnDescriptor extends ListViewColumnDescriptor {
 		@Override
 		public String getDisplayName() {
@@ -32,7 +52,7 @@ public class LastBuildTriggerColumn extends ListViewColumn {
 
 		@Override
 		public ListViewColumn newInstance(final StaplerRequest request, final JSONObject formData) throws FormException {
-			return new LastBuildTriggerColumn();
+			return request.bindJSON(LastBuildTriggerColumn.class, formData);
 		}
 
 		@Override

--- a/src/main/resources/org/jenkinsci/plugins/buildtriggerbadge/LastBuildTriggerColumn/column.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/buildtriggerbadge/LastBuildTriggerColumn/column.jelly
@@ -6,7 +6,10 @@
 				<j:forEach var="causeEntry" varStatus="status" items="${entries}">
 					<j:set var="causeIconUrl" value="${causeEntry.key}" />
 					<j:set var="causeShortDesc" value="${causeEntry.value}" />
-					<img width="16" height="16" src="${rootURL}${causeIconUrl}" title="${causeEntry.value}" />
+					<img width="16" height="16" src="${rootURL}${causeIconUrl}" title="${causeShortDesc}" />
+					<j:if test="${it.causeDisplayType.equals('iconAndDesc')}">
+						<span>&#160;${causeShortDesc}</span>
+					</j:if>
 					<j:if test="${!status.last}">
 						<br/>
 					</j:if>

--- a/src/main/resources/org/jenkinsci/plugins/buildtriggerbadge/LastBuildTriggerColumn/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/buildtriggerbadge/LastBuildTriggerColumn/config.jelly
@@ -1,0 +1,12 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+	<f:block>
+		<p>${%This column shows info about the cause of the last build}</p>
+		<f:entry title="${%Cause display format}">
+			<select name="causeDisplayType" class="setting-input">
+				<f:option value="iconOnly" selected="${instance.causeDisplayType.equals('iconOnly')}">${%Icon only}</f:option>
+				<f:option value="iconAndDesc" selected="${instance.causeDisplayType.equals('iconAndDesc')}">${%Icon and description}</f:option>
+			</select>
+		</f:entry>
+	</f:block>
+</j:jelly>


### PR DESCRIPTION
Users can now pick how to display build Cause in mentioned column,
since not all users want to see long descriptions.

By default column will display only icon for build cause.