### PR TITLE
WIP Shorten header for column

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/buildtriggerbadge/LastBuildTriggerColumn/column.properties
+++ b/src/main/resources/org/jenkinsci/plugins/buildtriggerbadge/LastBuildTriggerColumn/column.properties
@@ -1,2 +1,2 @@
-LastBuildTriggerColumn.DisplayName = Last Build Trigger
+LastBuildTriggerColumn.DisplayName = Last Trigger
 LastBuildTriggerColumn.NoCause = N/A


### PR DESCRIPTION
When "icon only" format is very short, but header name "Last Build Trigger" adds extra width. Also word "build" is redundant, because every line is build (or more generally run).
![screenshot 2015-09-18 18 15 56](https://cloud.githubusercontent.com/assets/231611/9962988/64d8180c-5e31-11e5-97df-61a0a000c7bc.png)
