### PR TITLE
Added support for github-integration-plugin

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/buildtriggerbadge/IconFinder.java
+++ b/src/main/java/org/jenkinsci/plugins/buildtriggerbadge/IconFinder.java
@@ -74,6 +74,7 @@ public class IconFinder {
 		defineIconForCause("org.jvnet.hudson.plugins.m2release.ReleaseCause", "user-cause.png");
 		defineIconForCause("com.cloudbees.jenkins.GitHubPushCause", "github-push-cause.png");
 		defineIconForCause("org.jenkinsci.plugins.ghprb.GhprbCause", "github-pull-request-cause.png");
+		defineIconForCause("org.jenkinsci.plugins.github.pullrequest.GitHubPRCause", "github-pull-request-cause.png");
 		defineIconForCause("org.jenkinsci.plugins.periodicreincarnation.PeriodicReincarnationBuildCause", "periodic-reincarnation.png");
 		defineIconForCause("com.chikli.hudson.plugin.naginator.NaginatorCause", "periodic-reincarnation.png");
 		defineIconForCause("com.cloudbees.plugins.flow.FlowCause", "flow-cause.png");


### PR DESCRIPTION
https://github.com/jenkinsci/github-integration-plugin triggers builds from Github pull requests. We want to see pull request badges with the builds triggered with this plugin.