### PR TITLE
Demonstrate new property to avoid adding implied dependencies for detached plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,8 @@
 		<revision>2.11</revision>
 		<changelist>-SNAPSHOT</changelist>
 
+		<hpi.noDetachedPluginUntil>2.112</hpi.noDetachedPluginUntil>
+
 	</properties>
 
 	<scm>


### PR DESCRIPTION
Demo for https://github.com/jenkinsci/maven-hpi-plugin/pull/91

New prop in the MANIFEST

```
$ unzip -c target/buildtriggerbadge.hpi META-INF/MANIFEST.MF | grep -i detached
No-Detached-Plugin-Until: 2.112
```