### PR TITLE
Added icon mapping for GenericWebhookTrigger plugin

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/buildtriggerbadge/IconFinder.java
+++ b/src/main/java/org/jenkinsci/plugins/buildtriggerbadge/IconFinder.java
@@ -89,6 +89,7 @@ public class IconFinder {
 		defineIconForCause("com.cloudbees.jenkins.plugins.BitBucketPushCause", "bitbucket.png");
 		defineIconForCause("hudson.plugins.git.GitStatus$CommitHookCause", "git-hook-cause.png");
 		defineIconForCause("org.jenkinsci.plugins.urltrigger.URLTriggerCause", "url-trigger-cause.png");
+		defineIconForCause("org.jenkinsci.plugins.gwt.GenericCause", "url-trigger-cause.png");
 		defineIconForCause("jenkins.branch.BranchIndexingCause", "branch-indexing-cause.png");
 		defineIconForCause("jenkins.branch.BranchEventCause", "branch-event-cause.png");
 		defineIconForCause("org.jenkinsci.plugins.workflow.cps.replay.ReplayCause", "periodic-reincarnation.png");


### PR DESCRIPTION
The plugin: https://plugins.jenkins.io/generic-webhook-trigger/ allows triggering jobs by remotely invoking URL on jenkins.

Copied from XML https://<jenkins>/job/<jobname>/<jobnumber>/api/xml?xpath=//cause&wrapper=causes :
 
```
<causes>
<cause _class="org.jenkinsci.plugins.gwt.GenericCause">
<shortDescription>Generic Cause</shortDescription>
</cause>
</causes>
```