### PR TITLE
Update Jenkinsfile syntax

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,6 @@ buildPlugin(configurations: [
     [ platform: "windows", jdk: "8", jenkins: null ],
 
     // More recent LTS candidate
-    [ platform: "linux", jdk: "8", jenkins: '2.332', javaLevel: "11" ],
+    [ platform: "linux", jdk: "8", jenkins: '2.332' ],
 
 ])


### PR DESCRIPTION
The javaLevel option is deprecated and does no longer set the Java version. The option is ignored.
This PR removes the unused option.