### PR TITLE
Show all non-vetoed build causes in column

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/buildtriggerbadge/BuildTriggerBadgeAction.java
+++ b/src/main/java/org/jenkinsci/plugins/buildtriggerbadge/BuildTriggerBadgeAction.java
@@ -3,7 +3,10 @@ package org.jenkinsci.plugins.buildtriggerbadge;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.model.BuildBadgeAction;
 import hudson.model.Cause;
+import hudson.model.Run;
+import java.util.List;
 import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.buildtriggerbadge.provider.BuildTriggerBadgeDeactivator;
 
 /**
  * Badge action of the build trigger cause.
@@ -13,6 +16,23 @@ import jenkins.model.Jenkins;
 public class BuildTriggerBadgeAction implements BuildBadgeAction {
 
     private final Cause cause;
+
+    /**
+     * Factory method to create build trigger badge actions for the run causes.
+     * Run causes will be deduped and filtered for deactivated badge causes.
+     * This method only creates new action instances, it does not add them
+     * to the run.
+     * @see CauseFilter
+     * @see BuildTriggerBadgeDeactivator
+     * @param run run instance to get build trigger actions for
+     * @return new list of build trigger badge actions for the run causes
+     */
+    @NonNull
+    static List<BuildTriggerBadgeAction> createForRun(@NonNull Run<?, ?> run) {
+        return CauseFilter.filter(run.getCauses(), BuildTriggerBadgeDeactivator.all()).stream()
+                .map(BuildTriggerBadgeAction::new)
+                .toList();
+    }
 
     /**
      * Initialize causes of the build.

--- a/src/main/java/org/jenkinsci/plugins/buildtriggerbadge/CauseFilter.java
+++ b/src/main/java/org/jenkinsci/plugins/buildtriggerbadge/CauseFilter.java
@@ -7,10 +7,15 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.apache.commons.collections.CollectionUtils;
+import org.jenkinsci.plugins.buildtriggerbadge.provider.BuildTriggerBadgeDeactivator;
 
 /**
  * Filtering possible duplicate causes
  *
+ * @see BuildTriggerBadgeDeactivator
  * @since 1.1
  *
  * @author Michael Pailloncy
@@ -18,19 +23,38 @@ import java.util.function.Predicate;
  */
 public class CauseFilter {
 
+    private static final java.util.logging.Logger LOGGER = Logger.getLogger(CauseFilter.class.getName());
+
     /**
-     * Filter causes by Class type and description
+     * Filter causes by Class type and description.
      *
      * @param inputCauses list of causes
-     * @return filtered list, possibly empty, never null
+     * @return filtered list, possibly empty, never {@code null}
      */
     @NonNull
     public static List<Cause> filter(@Nullable List<Cause> inputCauses) {
+        return filter(inputCauses, null);
+    }
+
+    /**
+     * Filter causes by excluding duplicate cause type and descriptions
+     * and deactivated badge causes.
+     *
+     * @param inputCauses list of causes
+     * @param deactivators list of cause deactivators, possibly {@code null}
+     * @return filtered list, possibly empty, never {@code null}
+     */
+    @NonNull
+    public static List<Cause> filter(
+            @Nullable List<Cause> inputCauses, @Nullable List<BuildTriggerBadgeDeactivator> deactivators) {
         if (inputCauses == null) {
             return List.of();
         }
 
-        return inputCauses.stream().filter(distinctCause()).toList();
+        return inputCauses.stream()
+                .filter(distinctCause())
+                .filter(notDeactivated(deactivators))
+                .toList();
     }
 
     private static Predicate<Cause> distinctCause() {
@@ -40,5 +64,24 @@ public class CauseFilter {
 
     private static String getCauseFilter(Cause cause) {
         return cause.getClass().getCanonicalName() + "_" + cause.getShortDescription();
+    }
+
+    private static Predicate<Cause> notDeactivated(@Nullable List<BuildTriggerBadgeDeactivator> deactivators) {
+        if (CollectionUtils.isEmpty(deactivators)) {
+            return cause -> true;
+        }
+
+        return cause -> {
+            for (BuildTriggerBadgeDeactivator deactivator : deactivators) {
+                if (deactivator.vetoBadge(cause)) {
+                    LOGGER.log(Level.FINE, "Badge for cause '{0}' disabled by extension '{1}'", new Object[] {
+                        cause, deactivator
+                    });
+                    return false;
+                }
+            }
+
+            return true;
+        };
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/buildtriggerbadge/IconFinder.java
+++ b/src/main/java/org/jenkinsci/plugins/buildtriggerbadge/IconFinder.java
@@ -19,10 +19,11 @@ import org.jenkinsci.plugins.buildtriggerbadge.provider.BuildTriggerBadgeProvide
  * Class responsible for finding the icon associated with a build cause.
  *
  * @author Baptiste Mathus
+ * @see BuildTriggerBadgeProvider
  */
 public class IconFinder {
 
-    private static final Logger LOGGER = Logger.getLogger(IconFinder.class.getSimpleName());
+    private static final Logger LOGGER = Logger.getLogger(IconFinder.class.getName());
 
     private final Cause cause;
 
@@ -30,6 +31,10 @@ public class IconFinder {
         this.cause = cause;
     }
 
+    /**
+     * Find icon for the configured cause.
+     * @return icon url or symbol
+     */
     @NonNull
     public String find() {
 
@@ -38,19 +43,18 @@ public class IconFinder {
             String providedIcon = provider.provideIcon(cause);
             if (providedIcon != null) {
                 LOGGER.log(Level.FINEST, "Badge for cause '{0}' set/overriden by extension '{1}': '{2}'", new Object[] {
-                    cause, provider.getClass().getSimpleName()
+                    cause, provider.getClass().getSimpleName(), providedIcon
                 });
                 return providedIcon;
             }
         }
 
         // internal lookup if nothing found previously
-        Class<?> clazz = cause.getClass();
-        return internalFindForClass(clazz);
+        return internalFindForClass(cause.getClass());
     }
 
     @NonNull
-    private String internalFindForClass(Class<?> clazz) {
+    private static String internalFindForClass(Class<?> clazz) {
         if (clazz == null) {
             return "symbol-help-outline plugin-ionicons-api";
         }

--- a/src/main/java/org/jenkinsci/plugins/buildtriggerbadge/LastBuildTriggerColumn.java
+++ b/src/main/java/org/jenkinsci/plugins/buildtriggerbadge/LastBuildTriggerColumn.java
@@ -2,15 +2,12 @@ package org.jenkinsci.plugins.buildtriggerbadge;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
-import hudson.model.Cause;
 import hudson.model.Descriptor;
 import hudson.model.Job;
 import hudson.model.Run;
 import hudson.views.ListViewColumn;
 import hudson.views.ListViewColumnDescriptor;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
@@ -62,16 +59,11 @@ public class LastBuildTriggerColumn extends ListViewColumn {
         return DESCRIPTOR;
     }
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    public Map<String, String> getLastBuildCauses(Job job) {
-        Run r = job.getLastBuild();
+    @SuppressWarnings({"unused"}) // used by jelly
+    public List<BuildTriggerBadgeAction> getLastBuildCauses(Job<?, ?> job) {
+        Run<?, ?> r = job.getLastBuild();
         if (r != null) {
-            List<Cause> lastCauses = CauseFilter.filter((List<Cause>) r.getCauses());
-            Map<String, String> causeEntries = new HashMap<>();
-            for (Cause cause : lastCauses) {
-                causeEntries.put(new BuildTriggerBadgeAction(cause).getIcon(), cause.getShortDescription());
-            }
-            return causeEntries;
+            return BuildTriggerBadgeAction.createForRun(r);
         }
 
         return null;

--- a/src/main/java/org/jenkinsci/plugins/buildtriggerbadge/RunListenerImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/buildtriggerbadge/RunListenerImpl.java
@@ -2,14 +2,9 @@ package org.jenkinsci.plugins.buildtriggerbadge;
 
 import hudson.Extension;
 import hudson.PluginWrapper;
-import hudson.model.Cause;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.model.listeners.RunListener;
-import java.util.List;
-import org.jenkinsci.plugins.buildtriggerbadge.provider.BuildTriggerBadgeDeactivator;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Listener to all build to add the badge action.
@@ -18,36 +13,13 @@ import org.slf4j.LoggerFactory;
  */
 @Extension
 public class RunListenerImpl extends RunListener<Run<?, ?>> {
-    private static final Logger LOGGER = LoggerFactory.getLogger(RunListenerImpl.class);
 
     @Override
     public void onStarted(Run build, TaskListener listener) {
         PluginWrapper plugin = BuildTriggerBadgePlugin.get();
         if (plugin.isActive()) {
-            List<Cause> causes = CauseFilter.filter(build.getCauses());
-            for (Cause cause : causes) {
-                if (isEnabled(cause)) {
-                    build.addAction(new BuildTriggerBadgeAction(cause));
-                }
-            }
+            BuildTriggerBadgeAction.createForRun(build).forEach(build::addAction);
         }
         super.onStarted(build, listener);
-    }
-
-    /**
-     * Checks all the {@link BuildTriggerBadgeDeactivator} implementations to see if the given cause should have its badge disabled.
-     *
-     * @param cause
-     *            the cause to be tested against potential deactivators.
-     * @return true if the cause is still to be given a badge, else false.
-     */
-    private boolean isEnabled(Cause cause) {
-        for (BuildTriggerBadgeDeactivator deactivator : BuildTriggerBadgeDeactivator.all()) {
-            if (deactivator.vetoBadge(cause)) {
-                LOGGER.debug("Badge for cause '{}' disabled by extension '{}'", cause, deactivator);
-                return false;
-            }
-        }
-        return true;
     }
 }

--- a/src/main/resources/org/jenkinsci/plugins/buildtriggerbadge/LastBuildTriggerColumn/column.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/buildtriggerbadge/LastBuildTriggerColumn/column.jelly
@@ -5,8 +5,8 @@
 		<j:choose>
 			<j:when test="${entries != null}">
 				<j:forEach var="causeEntry" varStatus="status" items="${entries}">
-					<j:set var="causeIconUrl" value="${causeEntry.key}" />
-					<j:set var="causeShortDesc" value="${causeEntry.value}" />
+					<j:set var="causeIconUrl" value="${causeEntry.icon}" />
+					<j:set var="causeShortDesc" value="${causeEntry.tooltip}" />
 					<l:icon src="${causeIconUrl}" tooltip="${causeShortDesc}" class="icon-sm"/>
 					<j:if test="${it.causeDisplayType.equals('iconAndDesc')}">
 						<span>&#160;${causeShortDesc}</span>

--- a/src/test/java/org/jenkinsci/plugins/buildtriggerbadge/BuildTriggerBadgeActionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/buildtriggerbadge/BuildTriggerBadgeActionTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.containsStringIgnoringCase;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.mockito.Mockito.mock;
@@ -13,10 +14,12 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.model.BuildBadgeAction;
 import hudson.model.Cause;
 import hudson.model.Cause.UpstreamCause;
+import hudson.model.CauseAction;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.queue.QueueTaskFuture;
 import hudson.triggers.SCMTrigger.SCMTriggerCause;
+import hudson.triggers.TimerTrigger;
 import java.util.List;
 import org.jenkinsci.plugins.buildtriggerbadge.provider.BuildTriggerBadgeDeactivator;
 import org.jenkinsci.plugins.buildtriggerbadge.provider.BuildTriggerBadgeProvider;
@@ -95,5 +98,16 @@ class BuildTriggerBadgeActionTest {
 
         List<BuildBadgeAction> badgeActions = build.getBadgeActions();
         assertThat(badgeActions, empty());
+    }
+
+    @Test
+    void createForRun() throws Exception {
+        FreeStyleProject project = j.createFreeStyleProject();
+        QueueTaskFuture<FreeStyleBuild> futureBuild = project.scheduleBuild2(
+                0, new SCMTriggerCause("Boum"), List.of(new CauseAction(new TimerTrigger.TimerTriggerCause())));
+        FreeStyleBuild build = futureBuild.get();
+        var badgeActions = BuildTriggerBadgeAction.createForRun(build);
+        assertThat(badgeActions, hasSize(1));
+        assertThat(badgeActions.get(0).getTooltip(), equalTo("Started by timer"));
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/buildtriggerbadge/CauseFilterTest.java
+++ b/src/test/java/org/jenkinsci/plugins/buildtriggerbadge/CauseFilterTest.java
@@ -3,10 +3,12 @@ package org.jenkinsci.plugins.buildtriggerbadge;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.model.Cause;
 import hudson.triggers.TimerTrigger;
 import java.util.List;
 import java.util.stream.Stream;
+import org.jenkinsci.plugins.buildtriggerbadge.provider.BuildTriggerBadgeDeactivator;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -28,5 +30,41 @@ class CauseFilterTest {
     @MethodSource("filterTestCases")
     void filter(List<Cause> input, List<Cause> output) {
         assertEquals(output, CauseFilter.filter(input));
+    }
+
+    static Stream<Arguments> filterWithDeactivatorsTestCases() {
+        var local1 = new Cause.RemoteCause("localhost", null);
+        var local2 = new Cause.RemoteCause("localhost", null);
+        var other1 = new Cause.RemoteCause("otherhost", null);
+        var other2 = new Cause.RemoteCause("otherhost2", null);
+        var deactLocal = new RemoteCauseHostDeactivator("localhost");
+        var deactOther = new RemoteCauseHostDeactivator("otherhost");
+        return Stream.of(
+                arguments(null, null, List.of()),
+                arguments(List.of(), null, List.of()),
+                arguments(List.of(local1, local2, other1, other2), null, List.of(local1, other1, other2)),
+                arguments(List.of(local1, local2, other1, other2), List.of(deactLocal), List.of(other1, other2)),
+                arguments(List.of(local1, local2, other1, other2), List.of(deactLocal, deactOther), List.of(other2)));
+    }
+
+    @ParameterizedTest
+    @MethodSource("filterWithDeactivatorsTestCases")
+    void filterWithDeactivators(
+            List<Cause> input, List<BuildTriggerBadgeDeactivator> deactivators, List<Cause> output) {
+        assertEquals(output, CauseFilter.filter(input, deactivators));
+    }
+
+    private static class RemoteCauseHostDeactivator extends BuildTriggerBadgeDeactivator {
+
+        private String host;
+
+        RemoteCauseHostDeactivator(String host) {
+            this.host = host;
+        }
+
+        @Override
+        public boolean vetoBadge(@NonNull Cause cause) {
+            return cause instanceof Cause.RemoteCause rc && host.equals(rc.getAddr());
+        }
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/buildtriggerbadge/LastBuildTriggerColumnTest.java
+++ b/src/test/java/org/jenkinsci/plugins/buildtriggerbadge/LastBuildTriggerColumnTest.java
@@ -1,0 +1,58 @@
+package org.jenkinsci.plugins.buildtriggerbadge;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import hudson.model.Cause;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.triggers.TimerTrigger;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+@WithJenkins
+class LastBuildTriggerColumnTest {
+
+    private FreeStyleProject job;
+
+    @BeforeEach
+    public void setUp() {
+        job = mock(FreeStyleProject.class);
+    }
+
+    @Test
+    void getLastBuildCauses() {
+        FreeStyleBuild lastRun = mock(FreeStyleBuild.class);
+        when(job.getLastBuild()).thenReturn(lastRun);
+        when(lastRun.getCauses())
+                .thenReturn(List.of(
+                        new Cause.RemoteCause("localhost", null),
+                        new Cause.RemoteCause("localhost", null),
+                        new Cause.RemoteCause("otherhost", null),
+                        new TimerTrigger.TimerTriggerCause(),
+                        new TimerTrigger.TimerTriggerCause()));
+        LastBuildTriggerColumn col = new LastBuildTriggerColumn();
+        List<BuildTriggerBadgeAction> lastBuildCauses = col.getLastBuildCauses(job);
+
+        assertEquals(
+                List.of(
+                        "symbol-radio-outline plugin-ionicons-api",
+                        "symbol-radio-outline plugin-ionicons-api",
+                        "symbol-time-outline plugin-ionicons-api"),
+                lastBuildCauses.stream().map(BuildTriggerBadgeAction::getIcon).toList());
+        assertEquals(
+                List.of("Started by remote host localhost", "Started by remote host otherhost", "Started by timer"),
+                lastBuildCauses.stream()
+                        .map(BuildTriggerBadgeAction::getTooltip)
+                        .toList());
+    }
+
+    @Test
+    void getLastBuildCausesLastRunNull() {
+        LastBuildTriggerColumn col = new LastBuildTriggerColumn();
+        assertNull(col.getLastBuildCauses(job));
+    }
+}


### PR DESCRIPTION
This change fixes an issue where the cause column would not show all causes if they used the same icon.

It also fixes an issue where the column would display causes that have been vetoed.

The column now displays all deduped and non-vetoed causes.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
