### PR TITLE
Set cursor style to default

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/buildtriggerbadge/BuildTriggerBadgeAction/badge.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/buildtriggerbadge/BuildTriggerBadgeAction/badge.jelly
@@ -1,7 +1,9 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
-	<j:if test="${it.plugin.activated}">
-		<l:icon tooltip="${it.tooltip}" alt="${it.displayName}"
-	     	 src="${it.icon}" class="icon-sm"/>
-	</j:if>
+    <j:if test="${it.plugin.activated}">
+        <span style="cursor: default">
+            <l:icon tooltip="${it.tooltip}" alt="${it.displayName}"
+                 src="${it.icon}" class="icon-sm"/>
+        </span>
+    </j:if>
 </j:jelly>


### PR DESCRIPTION
This change explicitly sets the badge cursor style to `default`. Recent style in jenkins core set the cursor style to pointer for the entire build item.

Fixes #193

<!-- Please describe your pull request here. -->

### Testing done

Validated with Jenkins 2.516.2

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
